### PR TITLE
Feat/config

### DIFF
--- a/include/AppendOnlyVec.h
+++ b/include/AppendOnlyVec.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "LogConfig.h"  // for wcc::log_debug
 #include <vector>
 
 #if defined(TEST)
@@ -44,6 +45,7 @@ public:
             chunks_.emplace_back();
             new_curr_ = chunks_.size() - 1;
             chunks_[new_curr_].reserve(Chunk::chunk_size);
+            wcc::log_debug("ChunkStorage::new_chunk: chunk_size:{}, current num of chunks:{}", Chunk::chunk_size, new_curr_);
         }
         return chunks_[new_curr_++]; // for moving
     }

--- a/include/AppendOnlyVec.h
+++ b/include/AppendOnlyVec.h
@@ -2,6 +2,7 @@
 
 #include "LogConfig.h"  // for wcc::log_debug
 #include <vector>
+#include <atomic>
 
 #if defined(TEST)
 #  include <fmt/format.h>
@@ -11,6 +12,14 @@
 #endif
 
 namespace wcc {
+
+struct SpinLock {
+    std::atomic_bool& locked;
+    SpinLock(std::atomic_bool& locked) : locked(locked) {
+        for (bool expected = false; !locked.compare_exchange_strong(expected, true); expected = false);
+    }
+    ~SpinLock() { locked = false; }
+};
 
 // ChunkStorage is not intended for outside
 template <typename Chunk>
@@ -31,6 +40,8 @@ public:
     size_t water_mark() const { return new_curr_; }
 
     Chunk& new_chunk() {
+        SpinLock lock(is_newing_);
+
         MY_ASSERT(new_curr_ <= chunks_.size(), (fmt::format("new_curr:{} <= N{}", new_curr_, chunks_.size())))
         if (new_curr_ == chunks_.size()) new_curr_ = 0;
 
@@ -59,6 +70,7 @@ public:
     }
 
 private:
+    std::atomic_bool is_newing_ = false;
     size_type new_curr_;
     size_type return_curr_;
     std::vector<Chunk> chunks_;

--- a/include/Config.h
+++ b/include/Config.h
@@ -66,7 +66,7 @@ inline YAML::Node load_full_config(std::string const& cfg_file, Replacements con
     if (!std::filesystem::exists(cfg_path))
         throw std::runtime_error(fmt::format("file {} does not exist", cfg_path.c_str()));
 
-    std::cout << "Loading " << cfg_path.native() << '\n';
+    fmt::print("Loading {}\n", cfg_path.native());
     auto node = YAML::LoadFile(cfg_path.native());
     load_full_config(node, replacements, cfg_root, path);
     return node;
@@ -79,5 +79,5 @@ inline YAML::Node load_full_config(std::string const& cfg_file, Replacements con
  */
 // int main() {
 //     auto cfg = load_full_config("Config/ManualWCTraderConfig.yaml", std::array{std::pair{"today", "20230927"}});
-//     std::cout << cfg << '\n';
+//     fmt::print("{}\n", cfg);
 // }

--- a/include/Config.h
+++ b/include/Config.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <yaml-cpp/yaml.h>
+#include <fmt/format.h>
+#include <regex>
+#include <filesystem>
+#include <ranges>
+
+namespace wcc {
+
+using Config = YAML::Node;
+
+template <typename T = std::string>
+T get_field(Config const& cfg, std::string_view key) {
+    try {
+        return cfg[std::string(key)].template as<T>();
+    } catch(std::exception const& e) {
+        throw std::runtime_error(fmt::format("Exception for config key \"{}\": {}", key, e.what()));
+    }
+}
+
+using Replacements = std::vector<std::pair<std::string, std::string>>;
+
+YAML::Node load_full_config(std::string const& cfg_file, Replacements const& replacements,
+                            std::string cfg_root = {}, std::filesystem::path path = {});
+
+static inline void load_full_config(YAML::Node& node, Replacements const& replacements,
+                                    std::string cfg_root, std::filesystem::path path) {
+    if (node.IsMap()) {  // root node must be a Map
+        for (auto it = node.begin(); it != node.end(); ++it) {
+            load_full_config(it->second, replacements, cfg_root, path);
+        }
+    } else if (node.IsSequence()) {
+    } else if (node.IsScalar()) {
+        auto str = node.as<std::string>();
+        if (str.ends_with(".yaml")) {  // && !std::regex_search(str, std::regex("\\$\\{.*\\}"))) {
+            auto n = load_full_config(str, replacements, cfg_root, path);
+            node = n;
+        }
+        else {  // do the rendering
+            for (auto& [k, v] : replacements) {
+                str = std::regex_replace(str, std::regex(std::string("\\$\\{") + k + "\\}"), v);
+            }
+            node = str;
+        }
+    } // else other type to process; to be added in the future
+}
+
+inline YAML::Node load_full_config(std::string const& cfg_file, Replacements const& replacements,
+                                   std::string cfg_root, std::filesystem::path path)
+{
+    namespace fs = std::filesystem;
+
+    if (cfg_root.empty()) cfg_root = fs::absolute(cfg_file).parent_path().string();
+
+    auto cfg_fname = std::regex_replace(cfg_file, std::regex(std::string("\\$\\{cfg_root\\}")), cfg_root);
+
+    fs::path cfg_path(cfg_fname);
+    // cfg_name == cfg_file means no cfg_root specified so take relative into account
+    if (cfg_fname == cfg_file && cfg_path.is_relative()) {
+        cfg_path = path / cfg_path;
+    }
+
+    path = cfg_path.parent_path();
+
+    if (!std::filesystem::exists(cfg_path))
+        throw std::runtime_error(fmt::format("file {} does not exist", cfg_path.c_str()));
+
+    std::cout << "Loading " << cfg_path.native() << '\n';
+    auto node = YAML::LoadFile(cfg_path.native());
+    load_full_config(node, replacements, cfg_root, path);
+    return node;
+}
+
+}  // namespace wcc
+
+/**
+ * Example: g++ -std=c++20 -I ~/dev/include -lyaml-cpp -g -o cfg cfg.cpp
+ */
+// int main() {
+//     auto cfg = load_full_config("Config/ManualWCTraderConfig.yaml", std::array{std::pair{"today", "20230927"}});
+//     std::cout << cfg << '\n';
+// }


### PR DESCRIPTION
Add config.h which originally is in Repo of WCTrader.  

There should have no effects on current production code since it's simply an addition of the file.

The use of this new config is in 
    a) WCTrader: feat/rpc-no-obs
    b) ReadySteadyGo: feat/thread-opt
    c) WCQuote: feat/config 