### PR TITLE
Allow ${cfg_root} in any config items of string type 

### DIFF
--- a/include/WCConfig.h
+++ b/include/WCConfig.h
@@ -41,6 +41,7 @@ static inline void load_full_config(YAML::Node& node, Replacements const& replac
             for (auto& [k, v] : replacements) {
                 str = std::regex_replace(str, std::regex(std::string("\\$\\{") + k + "\\}"), v);
             }
+            str = std::regex_replace(str, std::regex(std::string("\\$\\{cfg_root\\}")), cfg_root);
             node = str;
         }
     } // else other type to process; to be added in the future


### PR DESCRIPTION
Before this change, ${cfg_root} can be occur in items referencing to another .yaml file. Now it can be in any items which has a string type. 