### PR TITLE
Log format change: output function and event as it is

### DIFF
--- a/include/HJLogFormat.h
+++ b/include/HJLogFormat.h
@@ -40,6 +40,9 @@
 #include <boost/preprocessor/facilities/empty.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
 
+#ifndef FUN_EVT_FORMAT_STR
+#define FUN_EVT_FORMAT_STR "[{}] [{}]"   // [{:16.16s}] [{:12.12s}] "
+#endif
 
 // Macro helper to get the format string from a tuple
 #define FORMAT_STR_FROM_TUPLE(s,i,tuple) \
@@ -78,7 +81,7 @@
  */
 #define HJ_LOG(is_method, level, event, ...) {                                                            \
     constexpr auto fun_name = ::wcc::get_source_function_name(std::source_location::current());           \
-    HJ_THIS(is_method)log_##level("[{:16.16s}] [{:12.12s}] {{"                                            \
+    HJ_THIS(is_method)log_##level(FUN_EVT_FORMAT_STR "{{"                                                 \
         BOOST_PP_IF(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), COLLECT_FORMAT_STR, BOOST_PP_EMPTY)(__VA_ARGS__) \
         "}}", fun_name, event                                                                             \
         BOOST_PP_IF(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), COLLECT_VAR, BOOST_PP_EMPTY)(__VA_ARGS__));      \
@@ -93,12 +96,12 @@
 #define HJ_TLOG(is_method, level, event, ...) {                                                           \
     constexpr auto fun_name = ::wcc::get_source_function_name(std::source_location::current());           \
     if constexpr (HJ_HAS_ID(is_method)) {                                                                 \
-        HJ_THIS(is_method)log_##level("[{:16.16s}] [{:12.12s}] [{}] {{"                                   \
+        HJ_THIS(is_method)log_##level(FUN_EVT_FORMAT_STR "[{}] {{"                                        \
         BOOST_PP_IF(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), COLLECT_FORMAT_STR, BOOST_PP_EMPTY)(__VA_ARGS__) \
         "}}", fun_name, event, HJ_ID(is_method)                                                           \
         BOOST_PP_IF(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), COLLECT_VAR, BOOST_PP_EMPTY)(__VA_ARGS__));      \
     } else {                                                                                              \
-        HJ_THIS(is_method)log_##level("[{:16.16s}] [{:12.12s}] [-] {{"                                    \
+        HJ_THIS(is_method)log_##level(FUN_EVT_FORMAT_STR "[-] {{"                                         \
         BOOST_PP_IF(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), COLLECT_FORMAT_STR, BOOST_PP_EMPTY)(__VA_ARGS__) \
         "}}", fun_name, event                                                                             \
         BOOST_PP_IF(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), COLLECT_VAR, BOOST_PP_EMPTY)(__VA_ARGS__));      \
@@ -112,11 +115,11 @@
  *
  * Used in cases where the id cannot be obtained through the this->trader_id() call but does exist and needs to be output.
  */
-#define HJ_LOG_ID(is_method, level, event, trader_id, ...) {                                                     \
+#define HJ_LOG_ID(is_method, level, event, trader_id, ...) {                                              \
     constexpr auto fun_name = ::wcc::get_source_function_name(std::source_location::current());           \
-    HJ_THIS(is_method)log_##level("[{:16.16s}] [{:12.12s}] [{}] {{"                                       \
+    HJ_THIS(is_method)log_##level(FUN_EVT_FORMAT_STR "[{}] {{"                                            \
         BOOST_PP_IF(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), COLLECT_FORMAT_STR, BOOST_PP_EMPTY)(__VA_ARGS__) \
-        "}}", fun_name, event, trader_id                                                                         \
+        "}}", fun_name, event, trader_id                                                                  \
         BOOST_PP_IF(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), COLLECT_VAR, BOOST_PP_EMPTY)(__VA_ARGS__));      \
 }
 

--- a/tests/HJLogFormatTest.cpp
+++ b/tests/HJLogFormatTest.cpp
@@ -9,6 +9,7 @@
 */
 
 #include "LogConfig.h"
+#define FUN_EVT_FORMAT_STR "[{:16.16s}] [{:12.12s}] " // unittests are written based on this format
 #include "HJLogFormat.h"
 
 #include <catch2/catch_test_macros.hpp>


### PR DESCRIPTION
Changed format of function and event from "[{:16.16s}] [{:12.12s}] " to "[{}] [{}] ".